### PR TITLE
#24 [FIX] 비밀번호 재설정 페이지의 버튼 조건부 비활성화

### DIFF
--- a/src/pages/ResetPasswordPage/ResetPasswordPage.jsx
+++ b/src/pages/ResetPasswordPage/ResetPasswordPage.jsx
@@ -4,7 +4,9 @@ import EmailVerification from '../../components/EmailVerification/EmailVerificat
 import PasswordVerification from '../../components/PasswordVerification/PasswordVerification.jsx';
 import { RESET_PASSWORD_PAGE_TITLE } from '../../constants/index.js';
 import useFunnel from '../../hooks/useFunnel';
+import { checkEmailFormat, checkPasswordFormat } from '../../utils/checkFormat';
 import SubPage from '../SubPage/SubPage';
+
 export default function ResetPasswordPage() {
   const [formData, setFormData] = useState({
     email: '',
@@ -23,7 +25,11 @@ export default function ResetPasswordPage() {
       <Funnel.Step name='code'>
         <SubPage title={RESET_PASSWORD_PAGE_TITLE.step1}>
           <EmailVerification data={formData} onChange={handleChange} />
-          <DefaultButton text='확인' onClick={() => setStep('password')} />
+          <DefaultButton
+            text='확인'
+            onClick={() => setStep('password')}
+            disabled={!checkEmailFormat(formData.email) || !formData.code}
+          />
         </SubPage>
       </Funnel.Step>
       <Funnel.Step name='password'>
@@ -31,7 +37,10 @@ export default function ResetPasswordPage() {
           <PasswordVerification data={formData} onChange={handleChange} />
           <DefaultButton
             text='비밀번호 재설정 완료'
-            onClick={() => setStep('code')}
+            disabled={
+              !checkPasswordFormat(formData.password) ||
+              formData.password !== formData.rePassword
+            }
           />
         </SubPage>
       </Funnel.Step>


### PR DESCRIPTION
## 📍Issue Number or Link

- closed #24 
  </br>

## 🫧Description

비밀번호 재설정 페이지에서 각 단계별로 버튼을 조건부 비활성화하기.

### 이메일 인증 단계
- 이메일 포맷
- 인증코드
- 
### 비밀번호 설정 단계
- 비밀번호 포맷
- 비밀번호와 비밀번호 재입력 일치 여부

</br>

## ✨PR Type

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✔️PR Checklist

PR이 다음 요구 사항을 충족하는 지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](https://github.com/Team-Picle/Picle-Client) (Ctrl + 클릭하세요.)
