### PR TITLE
#86 [FIX] BottomSheet 언마운트 시 클릭 이벤트 핸들러 제거가 안 되는 문제 수정

### DIFF
--- a/src/components/BottomSheet/BottomSheet.jsx
+++ b/src/components/BottomSheet/BottomSheet.jsx
@@ -12,29 +12,31 @@ import BottomSheetTitle from './SubComponents/BottomSheetTitle';
 import styles from './BottomSheet.module.css';
 
 function BottomSheetMain({ children }) {
-  const { closeBottomSheet } = useBottomSheetContext();
+  const { isOpen, closeBottomSheet } = useBottomSheetContext();
   const bottomSheetPortal = document.getElementById('App');
-  const stopPropagation = (event) => event.stopPropagation();
 
-  // if (!idOpen) {
-  //   return null;
-  // }
+  useEffect(() => {
+    const close = (event) => {
+      if (!event.target.closest(`.${styles.bottomSheet}`)) {
+        closeBottomSheet();
+      }
+    };
 
-  if (!bottomSheetPortal) {
+    if (isOpen) {
+      document.addEventListener('click', close);
+    }
+
+    return () => {
+      document.removeEventListener('click', close);
+    };
+  }, [isOpen, closeBottomSheet]);
+
+  if (!isOpen || !bottomSheetPortal) {
     return null;
   }
 
-  useEffect(() => {
-    document.addEventListener('click', closeBottomSheet);
-
-    return () => {
-      document.removeEventListener('click', closeBottomSheet);
-    };
-  }, []);
-
   return createPortal(
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-    <div className={styles.bottomSheet} onClick={stopPropagation}>
+    <div className={styles.bottomSheet}>
       <div className={styles.header}>
         <span className={styles.handler} />
       </div>

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import { useBottomSheetContext } from 'contexts/BottomSheetContext';
 import { useDrawerContext } from 'contexts/DrawerContext';
 import { useUserContext } from 'contexts/UserContext';
 
@@ -21,7 +20,6 @@ export default function MainPage() {
   const { isOpen, toggleDrawer } = useDrawerContext();
   const [isLoading, setIsLoading] = useState();
   const [focusedMarker, setFocusedMarker] = useState();
-  const { isOpen: isOpenBottomSheet } = useBottomSheetContext();
 
   useEffect(() => {
     setIsLoading(true);
@@ -33,7 +31,6 @@ export default function MainPage() {
   if (isLoading) return <Animation animationData={lego} />;
 
   return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
     <section>
       <Navbar toggleDrawer={toggleDrawer} />
       <NaverMapWithMarker setFocusedMarker={setFocusedMarker} />
@@ -43,37 +40,35 @@ export default function MainPage() {
           <CTAButton type='white'>반납하기</CTAButton>
         </BottomSheet>
       )}
-      {isOpenBottomSheet && (
-        <BottomSheet>
-          <BottomSheet.Title>
-            숙명여대 {focusedMarker.label} 앞
-          </BottomSheet.Title>
-          <BottomSheet.Label>
-            <Icon
-              id='symbol'
-              fill='#1CAFFF'
-              width={18}
-              height={18}
-              style={{ marginRight: '0.25rem' }}
-            />
-            현재 대여 가능한 우산
-            <Icon
-              id='rightArrowLong'
-              fill='#1CAFFF'
-              width={95}
-              height={11}
-              style={{ margin: '0 0.5rem' }}
-            />
-            {focusedMarker.amount}개
-          </BottomSheet.Label>
-          <BottomSheet.Description hasArrowButton to='/rental-history'>
-            {GUIDE}
-          </BottomSheet.Description>
-          <Link to='qr-scan'>
-            <BottomSheet.Button>스캔하고 대여하기</BottomSheet.Button>
-          </Link>
-        </BottomSheet>
-      )}
+      <BottomSheet>
+        <BottomSheet.Title>
+          숙명여대 {focusedMarker?.label} 앞
+        </BottomSheet.Title>
+        <BottomSheet.Label>
+          <Icon
+            id='symbol'
+            fill='#1CAFFF'
+            width={18}
+            height={18}
+            style={{ marginRight: '0.25rem' }}
+          />
+          현재 대여 가능한 우산
+          <Icon
+            id='rightArrowLong'
+            fill='#1CAFFF'
+            width={95}
+            height={11}
+            style={{ margin: '0 0.5rem' }}
+          />
+          {focusedMarker?.amount}개
+        </BottomSheet.Label>
+        <BottomSheet.Description hasArrowButton to='/rental-history'>
+          {GUIDE}
+        </BottomSheet.Description>
+        <Link to='qr-scan'>
+          <BottomSheet.Button>스캔하고 대여하기</BottomSheet.Button>
+        </Link>
+      </BottomSheet>
     </section>
   );
 }


### PR DESCRIPTION
## 🎯 관련 이슈

close #86 

<br />

## 🚀 작업 내용

- BottomSheet의 열림/닫힘 상태를 나타내는 isOpen이 `true`일 때만 document에 `close` 핸들러를 등록하고, 언마운트 시 클릭 이벤트 핸들러를 삭제

<br />


## 🔎 발견된 장애가 있었나요?

- BottomSheet가 닫힌 후에도 화면 클릭 시 document에 등록했던 클릭 이벤트 핸들러(`closeBottomSheet`)가 호출되는 문제 발생했다.

<br />


<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
